### PR TITLE
Update directory_tag.rb

### DIFF
--- a/_plugins/directory_tag.rb
+++ b/_plugins/directory_tag.rb
@@ -83,7 +83,7 @@ module Jekyll
             slug = slug
           else
             date = File.ctime(filename)
-            ext = basename[/\.[a-z]+$/, 0]
+            ext = File.extname(basename)
             slug = ext ? basename.sub(ext, '') : basename
           end
 


### PR DESCRIPTION
The regular expression based code would fail with the following on Windows:
  Liquid Exception: wrong argument type nil (expected Regexp) in download/index.md
C:/lv2/website/_plugins/directory_tag.rb:84:in `sub': wrong argument type nil (expected Rege
        from C:/lv2/website/_plugins/directory_tag.rb:84:in `block (2 levels) in render'